### PR TITLE
typo, use var for js files

### DIFF
--- a/modui-base.js
+++ b/modui-base.js
@@ -74,7 +74,7 @@ Backbone.ModuiBase = Super.extend( {
 	},
 
 	_encapsulateEvent : function( e ) {
-		let encapsulatedEvent = _.pick( e, [ 'keyCode', 'metaKey', 'ctrlKey', 'altKey', 'shiftKey' ] );
+		var encapsulatedEvent = _.pick( e, [ 'keyCode', 'metaKey', 'ctrlKey', 'altKey', 'shiftKey' ] );
 
 		_.each( [ 'preventDefault', 'stopPropagation', 'stopImmediatePropagation' ], function( thisMethod ) {
 			encapsulatedEvent[ thisMethod ] = function() {


### PR DESCRIPTION
Hi @dgbeck, this is causing and error in iOS 9.3 ( `let` keyword ). Can you merge and publish a new version.

Thx!